### PR TITLE
fix: update API domain to api.monarch.com

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ import FormData from 'form-data';
 import { authenticator } from 'otplib';
 
 export class MonarchMoneyEndpoints {
-    static BASE_URL = "https://api.monarchmoney.com";
+    static BASE_URL = "https://api.monarch.com";
 
     static getLoginEndpoint() {
         return this.BASE_URL + "/auth/login/";

--- a/src/constants.js
+++ b/src/constants.js
@@ -13,7 +13,7 @@ export const AUTH_HEADER_KEY = "Authorization";
 export const CSRF_KEY = "csrftoken";
 export const DEFAULT_RECORD_LIMIT = 100;
 export const ERRORS_KEY = "error_code";
-export const BASE_URL = "https://api.monarchmoney.com"
+export const BASE_URL = "https://api.monarch.com"
 export const GQL_ENDPOINT = `${BASE_URL}/graphql`;
 
 export const MonarchMoneyEndpoints = {


### PR DESCRIPTION
## Summary

Monarch Money has migrated their API to a new domain. The old domain (`api.monarchmoney.com`) now returns HTTP 525 SSL handshake errors, making the package non-functional.

This PR updates `BASE_URL` in both `index.js` and `src/constants.js` from `https://api.monarchmoney.com` to `https://api.monarch.com`.

## Changes

- `index.js`: Updated `MonarchMoneyEndpoints.BASE_URL`
- `src/constants.js`: Updated `BASE_URL` constant